### PR TITLE
Add Parallax 1-2-3 FPGA(A7) board support to standard P1V emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ c5_pin_model_dump.txt
 *.pof
 *.qdf
 *.qws
+*.rbf
 *.rpt
 *.sld
 *.sof
@@ -22,3 +23,5 @@ db/
 incremental_db/
 simulation/
 hc_output/
+output_files/
+

--- a/HDL/P1V_Altera.qpf
+++ b/HDL/P1V_Altera.qpf
@@ -18,17 +18,18 @@
 # -------------------------------------------------------------------------- #
 #
 # Quartus II 64-Bit
-# Version 15.0.1 Build 150 06/03/2015 SJ Web Edition
-# Date created = 01:05:11  July 26, 2015
+# Version 15.0.2 Build 153 07/15/2015 SJ Web Edition
+# Date created = 16:56:52  July 30, 2015
 #
 # -------------------------------------------------------------------------- #
 
 QUARTUS_VERSION = "15.0"
-DATE = "01:05:11  July 26, 2015"
+DATE = "16:56:52  July 30, 2015"
 
 # Revisions
 
-PROJECT_REVISION = "BeMicroCV-A9"
+PROJECT_REVISION = "fpga123"
 PROJECT_REVISION = "BeMicroCV"
-PROJECT_REVISION = "DE2-115"
 PROJECT_REVISION = "DE0-Nano"
+PROJECT_REVISION = "DE2-115"
+PROJECT_REVISION = "BeMicroCV-A9"

--- a/HDL/fpga123.qsf
+++ b/HDL/fpga123.qsf
@@ -36,6 +36,10 @@
 # -------------------------------------------------------------------------- #
 
 
+# This is the standard .qsf file for the Parallax 1-2-3-FPGA (A7) board #60054
+# originally provided in a .zipfile on 7-21-15 by Parallax to A7 board purchasers
+# 
+
 set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CEFA7F23C8
 set_global_assignment -name TOP_LEVEL_ENTITY fpga123

--- a/HDL/fpga123.qsf
+++ b/HDL/fpga123.qsf
@@ -1,0 +1,358 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 1991-2011 Altera Corporation
+# Your use of Altera Corporation's design tools, logic functions 
+# and other software and tools, and its AMPP partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Altera Program License 
+# Subscription Agreement, Altera MegaCore Function License 
+# Agreement, or other applicable license agreement, including, 
+# without limitation, that your use is for the sole purpose of 
+# programming logic devices manufactured by Altera and sold by 
+# Altera or its authorized distributors.  Please refer to the 
+# applicable agreement for further details.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus II 64-Bit
+# Version 11.1 Build 259 01/25/2012 Service Pack 2 SJ Full Version
+# Date created = 13:08:54  October 05, 2012
+#
+# -------------------------------------------------------------------------- #
+#
+# Notes:
+#
+# 1) The default values for assignments are stored in the file:
+#		top_assignment_defaults.qdf
+#    If this file doesn't exist, see file:
+#		assignment_defaults.qdf
+#
+# 2) Altera recommends that you do not modify this file. This
+#    file is updated automatically by the Quartus II software
+#    and any changes you make may be lost or overwritten.
+#
+# -------------------------------------------------------------------------- #
+
+
+set_global_assignment -name FAMILY "Cyclone V"
+set_global_assignment -name DEVICE 5CEFA7F23C8
+set_global_assignment -name TOP_LEVEL_ENTITY fpga123
+set_global_assignment -name ORIGINAL_QUARTUS_VERSION "11.1 SP2"
+set_global_assignment -name PROJECT_CREATION_TIME_DATE "13:08:54  OCTOBER 05, 2012"
+set_global_assignment -name LAST_QUARTUS_VERSION 15.0.2
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "2.5 V"
+
+set_location_assignment PIN_E10 -to clock_50
+set_location_assignment PIN_F9 -to clock_io
+set_location_assignment PIN_G10 -to clock_in
+set_location_assignment PIN_F10 -to clock_out
+
+set_location_assignment PIN_B11 -to led[15]
+set_location_assignment PIN_C11 -to led[14]
+set_location_assignment PIN_E12 -to led[13]
+set_location_assignment PIN_D12 -to led[12]
+set_location_assignment PIN_K9 -to led[11]
+set_location_assignment PIN_L8 -to led[10]
+set_location_assignment PIN_G12 -to led[9]
+set_location_assignment PIN_H11 -to led[8]
+set_location_assignment PIN_A12 -to led[7]
+set_location_assignment PIN_B12 -to led[6]
+set_location_assignment PIN_C13 -to led[5]
+set_location_assignment PIN_D13 -to led[4]
+set_location_assignment PIN_F12 -to led[3]
+set_location_assignment PIN_G11 -to led[2]
+set_location_assignment PIN_G13 -to led[1]
+set_location_assignment PIN_H13 -to led[0]
+
+set_location_assignment PIN_H21 -to dac0_r[0]
+set_location_assignment PIN_G21 -to dac0_r[1]
+set_location_assignment PIN_E21 -to dac0_r[2]
+set_location_assignment PIN_D21 -to dac0_r[3]
+set_location_assignment PIN_E19 -to dac0_r[4]
+set_location_assignment PIN_D19 -to dac0_r[5]
+set_location_assignment PIN_C20 -to dac0_r[6]
+set_location_assignment PIN_B20 -to dac0_r[7]
+set_location_assignment PIN_J21 -to dac0_r[8]
+set_location_assignment PIN_J22 -to dac0_r[9]
+
+set_location_assignment PIN_B18 -to dac0_g[0]
+set_location_assignment PIN_B17 -to dac0_g[1]
+set_location_assignment PIN_C21 -to dac0_g[2]
+set_location_assignment PIN_B21 -to dac0_g[3]
+set_location_assignment PIN_G22 -to dac0_g[4]
+set_location_assignment PIN_F22 -to dac0_g[5]
+set_location_assignment PIN_G20 -to dac0_g[6]
+set_location_assignment PIN_H20 -to dac0_g[7]
+set_location_assignment PIN_E22 -to dac0_g[8]
+set_location_assignment PIN_D22 -to dac0_g[9]
+
+set_location_assignment PIN_C19 -to dac0_b[0]
+set_location_assignment PIN_C18 -to dac0_b[1]
+set_location_assignment PIN_B22 -to dac0_b[2]
+set_location_assignment PIN_A22 -to dac0_b[3]
+set_location_assignment PIN_F19 -to dac0_b[4]
+set_location_assignment PIN_F18 -to dac0_b[5]
+set_location_assignment PIN_E20 -to dac0_b[6]
+set_location_assignment PIN_F20 -to dac0_b[7]
+set_location_assignment PIN_A18 -to dac0_b[8]
+set_location_assignment PIN_A17 -to dac0_b[9]
+
+set_location_assignment PIN_A19 -to dac1_r[0]
+set_location_assignment PIN_K20 -to dac1_r[1]
+set_location_assignment PIN_K19 -to dac1_r[2]
+set_location_assignment PIN_B16 -to dac1_r[3]
+set_location_assignment PIN_C16 -to dac1_r[4]
+set_location_assignment PIN_D17 -to dac1_r[5]
+set_location_assignment PIN_E16 -to dac1_r[6]
+set_location_assignment PIN_G17 -to dac1_r[7]
+set_location_assignment PIN_G16 -to dac1_r[8]
+set_location_assignment PIN_G18 -to dac1_r[9]
+
+set_location_assignment PIN_H18 -to dac1_g[0]
+set_location_assignment PIN_J19 -to dac1_g[1]
+set_location_assignment PIN_J18 -to dac1_g[2]
+set_location_assignment PIN_E15 -to dac1_g[3]
+set_location_assignment PIN_F15 -to dac1_g[4]
+set_location_assignment PIN_A15 -to dac1_g[5]
+set_location_assignment PIN_A14 -to dac1_g[6]
+set_location_assignment PIN_J17 -to dac1_g[7]
+set_location_assignment PIN_K16 -to dac1_g[8]
+set_location_assignment PIN_C15 -to dac1_g[9]
+
+set_location_assignment PIN_B15 -to dac1_b[0]
+set_location_assignment PIN_G15 -to dac1_b[1]
+set_location_assignment PIN_F14 -to dac1_b[2]
+set_location_assignment PIN_H14 -to dac1_b[3]
+set_location_assignment PIN_J13 -to dac1_b[4]
+set_location_assignment PIN_B13 -to dac1_b[5]
+set_location_assignment PIN_A13 -to dac1_b[6]
+set_location_assignment PIN_E14 -to dac1_b[7]
+set_location_assignment PIN_F13 -to dac1_b[8]
+set_location_assignment PIN_J11 -to dac1_b[9]
+
+set_location_assignment PIN_A20 -to dac0_clk
+set_location_assignment PIN_H10 -to dac1_clk
+
+set_location_assignment PIN_AB12 -to expm[0]
+set_location_assignment PIN_AB13 -to expm[1]
+set_location_assignment PIN_U13 -to expm[2]
+set_location_assignment PIN_V13 -to expm[3]
+set_location_assignment PIN_T13 -to expm[4]
+set_location_assignment PIN_T12 -to expm[5]
+set_location_assignment PIN_AA13 -to expm[6]
+set_location_assignment PIN_AA14 -to expm[7]
+set_location_assignment PIN_AA15 -to expm[8]
+set_location_assignment PIN_AB15 -to expm[9]
+set_location_assignment PIN_Y15 -to expm[10]
+set_location_assignment PIN_Y14 -to expm[11]
+set_location_assignment PIN_V15 -to expm[12]
+set_location_assignment PIN_V14 -to expm[13]
+set_location_assignment PIN_AB18 -to expm[14]
+set_location_assignment PIN_AB17 -to expm[15]
+set_location_assignment PIN_AB21 -to expm[16]
+set_location_assignment PIN_AB20 -to expm[17]
+set_location_assignment PIN_Y17 -to expm[18]
+set_location_assignment PIN_Y16 -to expm[19]
+set_location_assignment PIN_U15 -to expm[20]
+set_location_assignment PIN_T14 -to expm[21]
+set_location_assignment PIN_AA18 -to expm[22]
+set_location_assignment PIN_AA17 -to expm[23]
+set_location_assignment PIN_AA20 -to expm[24]
+set_location_assignment PIN_AA19 -to expm[25]
+set_location_assignment PIN_W19 -to expm[26]
+set_location_assignment PIN_V20 -to expm[27]
+set_location_assignment PIN_W16 -to expm[28]
+set_location_assignment PIN_V16 -to expm[29]
+set_location_assignment PIN_AA22 -to expm[30]
+set_location_assignment PIN_AB22 -to expm[31]
+set_location_assignment PIN_W22 -to expm[32]
+set_location_assignment PIN_Y22 -to expm[33]
+set_location_assignment PIN_Y19 -to expm[34]
+set_location_assignment PIN_Y20 -to expm[35]
+set_location_assignment PIN_R14 -to expm[36]
+set_location_assignment PIN_P14 -to expm[37]
+set_location_assignment PIN_W21 -to expm[38]
+set_location_assignment PIN_Y21 -to expm[39]
+set_location_assignment PIN_V21 -to expm[40]
+set_location_assignment PIN_U22 -to expm[41]
+set_location_assignment PIN_V18 -to expm[42]
+set_location_assignment PIN_V19 -to expm[43]
+set_location_assignment PIN_U17 -to expm[44]
+set_location_assignment PIN_U16 -to expm[45]
+set_location_assignment PIN_U20 -to expm[46]
+set_location_assignment PIN_U21 -to expm[47]
+
+set_location_assignment PIN_AB4 -to data[0]
+set_location_assignment PIN_AB3 -to data[1]
+set_location_assignment PIN_AA5 -to data[2]
+set_location_assignment PIN_T4 -to data[3]
+set_location_assignment PIN_R4 -to data[4]
+set_location_assignment PIN_U7 -to data[5]
+set_location_assignment PIN_R6 -to data[6]
+set_location_assignment PIN_U8 -to data[7]
+set_location_assignment PIN_R5 -to data[8]
+set_location_assignment PIN_W8 -to data[9]
+set_location_assignment PIN_P6 -to data[10]
+set_location_assignment PIN_W9 -to data[11]
+set_location_assignment PIN_N6 -to data[12]
+set_location_assignment PIN_U6 -to data[13]
+set_location_assignment PIN_T7 -to data[14]
+set_location_assignment PIN_V6 -to data[15]
+
+set_location_assignment PIN_M7 -to pb[0]
+set_location_assignment PIN_M6 -to pb[1]
+set_location_assignment PIN_P7 -to pb[2]
+set_location_assignment PIN_R7 -to pb[3]
+
+set_location_assignment PIN_V3 -to px_clk
+set_location_assignment PIN_K6 -to px_enan
+
+set_location_assignment PIN_L7 -to expa[0]
+set_location_assignment PIN_K7 -to expa[1]
+set_location_assignment PIN_J7 -to expa[2]
+set_location_assignment PIN_J8 -to expa[3]
+set_location_assignment PIN_H8 -to expa[4]
+set_location_assignment PIN_G8 -to expa[5]
+set_location_assignment PIN_J9 -to expa[6]
+set_location_assignment PIN_H9 -to expa[7]
+
+set_location_assignment PIN_A10 -to expb[0]
+set_location_assignment PIN_A9 -to expb[1]
+set_location_assignment PIN_B10 -to expb[2]
+set_location_assignment PIN_C9 -to expb[3]
+set_location_assignment PIN_A5 -to expb[4]
+set_location_assignment PIN_B5 -to expb[5]
+set_location_assignment PIN_B6 -to expb[6]
+set_location_assignment PIN_B7 -to expb[7]
+
+set_location_assignment PIN_A8 -to expc[0]
+set_location_assignment PIN_A7 -to expc[1]
+set_location_assignment PIN_C6 -to expc[2]
+set_location_assignment PIN_D6 -to expc[3]
+set_location_assignment PIN_E9 -to expc[4]
+set_location_assignment PIN_D9 -to expc[5]
+set_location_assignment PIN_D7 -to expc[6]
+set_location_assignment PIN_C8 -to expc[7]
+
+set_location_assignment PIN_T19 -to p[0]
+set_location_assignment PIN_T20 -to p[1]
+set_location_assignment PIN_T18 -to p[2]
+set_location_assignment PIN_T17 -to p[3]
+set_location_assignment PIN_T22 -to p[4]
+set_location_assignment PIN_R22 -to p[5]
+set_location_assignment PIN_T15 -to p[6]
+set_location_assignment PIN_R15 -to p[7]
+set_location_assignment PIN_R21 -to p[8]
+set_location_assignment PIN_P22 -to p[9]
+set_location_assignment PIN_R16 -to p[10]
+set_location_assignment PIN_R17 -to p[11]
+set_location_assignment PIN_P19 -to p[12]
+set_location_assignment PIN_P18 -to p[13]
+set_location_assignment PIN_P16 -to p[14]
+set_location_assignment PIN_P17 -to p[15]
+set_location_assignment PIN_N16 -to p[16]
+set_location_assignment PIN_M16 -to p[17]
+set_location_assignment PIN_N20 -to p[18]
+set_location_assignment PIN_N21 -to p[19]
+set_location_assignment PIN_N19 -to p[20]
+set_location_assignment PIN_M18 -to p[21]
+set_location_assignment PIN_M22 -to p[22]
+set_location_assignment PIN_L22 -to p[23]
+set_location_assignment PIN_K17 -to p[24]
+set_location_assignment PIN_L17 -to p[25]
+set_location_assignment PIN_M20 -to p[26]
+set_location_assignment PIN_M21 -to p[27]
+set_location_assignment PIN_L19 -to p[28]
+set_location_assignment PIN_L18 -to p[29]
+set_location_assignment PIN_K21 -to p[30]
+set_location_assignment PIN_K22 -to p[31]
+set_location_assignment PIN_AB5 -to p[32]
+set_location_assignment PIN_AB6 -to p[33]
+set_location_assignment PIN_V10 -to p[34]
+set_location_assignment PIN_V9 -to p[35]
+set_location_assignment PIN_N8 -to p[36]
+set_location_assignment PIN_P8 -to p[37]
+set_location_assignment PIN_AB7 -to p[38]
+set_location_assignment PIN_AA7 -to p[39]
+set_location_assignment PIN_AB8 -to p[40]
+set_location_assignment PIN_AA8 -to p[41]
+set_location_assignment PIN_U10 -to p[42]
+set_location_assignment PIN_T9 -to p[43]
+set_location_assignment PIN_M9 -to p[44]
+set_location_assignment PIN_M8 -to p[45]
+set_location_assignment PIN_AA9 -to p[46]
+set_location_assignment PIN_AA10 -to p[47]
+set_location_assignment PIN_Y9 -to p[48]
+set_location_assignment PIN_Y10 -to p[49]
+set_location_assignment PIN_R9 -to p[50]
+set_location_assignment PIN_T10 -to p[51]
+set_location_assignment PIN_U12 -to p[52]
+set_location_assignment PIN_U11 -to p[53]
+set_location_assignment PIN_P12 -to p[54]
+set_location_assignment PIN_R12 -to p[55]
+set_location_assignment PIN_AB11 -to p[56]
+set_location_assignment PIN_AB10 -to p[57]
+set_location_assignment PIN_R11 -to p[58]
+set_location_assignment PIN_R10 -to p[59]
+set_location_assignment PIN_N9 -to p[60]
+set_location_assignment PIN_P9 -to p[61]
+set_location_assignment PIN_AA12 -to p[62]
+set_location_assignment PIN_Y11 -to p[63]
+
+set_location_assignment PIN_H6 -to fpga_resn
+set_location_assignment PIN_F7 -to fpga_rx
+set_location_assignment PIN_E7 -to fpga_tx
+
+set_location_assignment PIN_G6 -to fpga_rgb_leds
+
+
+set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2005
+set_global_assignment -name VERILOG_SHOW_LMF_MAPPING_MESSAGES OFF
+set_global_assignment -name USE_CONFIGURATION_DEVICE OFF
+set_global_assignment -name CRC_ERROR_OPEN_DRAIN OFF
+set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
+set_global_assignment -name OUTPUT_IO_TIMING_NEAR_END_VMEAS "HALF VCCIO" -rise
+set_global_assignment -name OUTPUT_IO_TIMING_NEAR_END_VMEAS "HALF VCCIO" -fall
+set_global_assignment -name OUTPUT_IO_TIMING_FAR_END_VMEAS "HALF SIGNAL SWING" -rise
+set_global_assignment -name OUTPUT_IO_TIMING_FAR_END_VMEAS "HALF SIGNAL SWING" -fall
+
+set_global_assignment -name OPTIMIZE_HOLD_TIMING "ALL PATHS"
+set_global_assignment -name OPTIMIZE_MULTI_CORNER_TIMING ON
+set_global_assignment -name SEED 1
+
+set_global_assignment -name TIMEQUEST_MULTICORNER_ANALYSIS ON
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
+set_global_assignment -name PHYSICAL_SYNTHESIS_REGISTER_RETIMING OFF
+set_global_assignment -name PHYSICAL_SYNTHESIS_ASYNCHRONOUS_SIGNAL_PIPELINING OFF
+set_global_assignment -name PHYSICAL_SYNTHESIS_REGISTER_DUPLICATION OFF
+set_global_assignment -name CYCLONEII_OPTIMIZATION_TECHNIQUE BALANCED
+set_global_assignment -name SYNTH_TIMING_DRIVEN_SYNTHESIS ON
+set_global_assignment -name FITTER_EFFORT "AUTO FIT"
+set_global_assignment -name SAVE_DISK_SPACE OFF
+set_global_assignment -name SMART_RECOMPILE ON
+set_global_assignment -name QII_AUTO_PACKED_REGISTERS AUTO
+set_global_assignment -name REMOVE_DUPLICATE_REGISTERS OFF
+set_global_assignment -name DEVICE_FILTER_PACKAGE FBGA
+set_global_assignment -name DEVICE_FILTER_PIN_COUNT 484
+set_global_assignment -name DEVICE_FILTER_SPEED_GRADE 8
+set_global_assignment -name SYNTH_PROTECT_SDC_CONSTRAINT ON
+set_global_assignment -name DISABLE_REGISTER_MERGING_ACROSS_HIERARCHIES ON
+set_global_assignment -name STRATIXV_CONFIGURATION_SCHEME "PASSIVE PARALLEL X8"
+set_global_assignment -name GENERATE_RBF_FILE ON
+set_global_assignment -name ON_CHIP_BITSTREAM_DECOMPRESSION ON
+set_global_assignment -name LOGICLOCK_INCREMENTAL_COMPILE_ASSIGNMENT ON
+set_global_assignment -name VERILOG_FILE fpga123.v
+set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
+set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
+set_global_assignment -name ENABLE_OCT_DONE OFF
+set_global_assignment -name ENABLE_CONFIGURATION_PINS OFF
+set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF
+set_global_assignment -name ACTIVE_SERIAL_CLOCK FREQ_100MHZ
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/HDL/fpga123.v
+++ b/HDL/fpga123.v
@@ -1,4 +1,6 @@
-// Top-level module for 1-2-3 FPGA
+// Top-level module for Parallax 1-2-3 FPGA A7 Version (#60054)
+//
+// Created from BeMicroCV-A9.v by Rick Post (aka Mindrobots) 7-31-15
 
 /*
 -------------------------------------------------------------------------------
@@ -26,19 +28,20 @@ the Propeller 1 Design.  If not, see <http://www.gnu.org/licenses/>.
 module              fpga123
 (
 
+// pull pin assignments from .qsf file definitions
+
 input               clock_50,
-output wire   [15:0] led,
-input         [3:0] pb,
-inout wire   [63:0] p,
-inout wire   fpga_rx,
-inout wire   fpga_tx,
-inout wire   fpga_resn
+output wire   [15:0] led,   // use all the user LEDS for COG indicators   
+inout wire   [31:0] p,
+inout wire   fpga_rx,   // use the 1-2-3-FPGA USB serial I/O   
+inout wire   fpga_tx,   // instaed of a prop plug - board must 
+inout wire   fpga_resn  // be in "Run" mode for this to be active
 
 
 );
 
 //
-// Reset can come from Prop plug or tactile switch
+// Reset comes from USB port serial connection
 //
 
 wire resn;
@@ -47,11 +50,12 @@ assign resn = fpga_resn;
 
 //
 // The LEDs are on when set to 0, so we reverse the cog led outputs here
-//
+// 1-2-3-FPGA has 16 user LEDs - default is to use 0-7 to indicate active
+// and 8-15 to indicate inactive COG
 
 wire[8:1] cogled;
-assign led[7:0] = ~cogled[8:1];
-assign led[15:8] = cogled[8:1];
+assign led[7:0] = ~cogled[8:1]; // lit when COG is active
+assign led[15:8] = cogled[8:1]; // lit when COG is inactive
 
 //
 // Inputs

--- a/HDL/fpga123.v
+++ b/HDL/fpga123.v
@@ -1,0 +1,166 @@
+// Top-level module for 1-2-3 FPGA
+
+/*
+-------------------------------------------------------------------------------
+
+This file is part of the hardware description for the Propeller 1 Design.
+
+The Propeller 1 Design is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+The Propeller 1 Design is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+more details.
+
+You should have received a copy of the GNU General Public License along with
+the Propeller 1 Design.  If not, see <http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------------
+*/
+
+`include "p1v.v"
+`include "altera.v"
+
+module              fpga123
+(
+
+input               clock_50,
+output wire   [15:0] led,
+input         [3:0] pb,
+inout wire   [63:0] p,
+inout wire   fpga_rx,
+inout wire   fpga_tx,
+inout wire   fpga_resn
+
+
+);
+
+//
+// Reset can come from Prop plug or tactile switch
+//
+
+wire resn;
+
+assign resn = fpga_resn;
+
+//
+// The LEDs are on when set to 0, so we reverse the cog led outputs here
+//
+
+wire[8:1] cogled;
+assign led[7:0] = ~cogled[8:1];
+assign led[15:8] = cogled[8:1];
+
+//
+// Inputs
+//
+
+wire[31:0] pin_in = 
+{
+    fpga_rx,
+    fpga_tx,
+    p[29],
+    p[28],
+    p[27],
+    p[26],
+    p[25],
+    p[24],
+    p[23],
+    p[22],
+    p[21],
+    p[20],
+    p[19],
+    p[18],
+    p[17],
+    p[16],
+    p[15],
+    p[14],
+    p[13],
+    p[12],
+    p[11],
+    p[10],
+    p[9],
+    p[8],
+    p[7],
+    p[6],
+    p[5],
+    p[4],
+    p[3],
+    p[2],
+    p[1],
+    p[0]
+};
+
+wire[31:0] pin_out;
+wire[31:0] pin_dir;
+
+
+
+//
+// Outputs
+//
+
+`define DIROUT(x) (pin_dir[x] ? pin_out[x] : 1'bZ)
+assign fpga_rx = `DIROUT(31);
+assign fpga_tx = `DIROUT(30);
+assign p[29] = `DIROUT(29);
+assign p[28] = `DIROUT(28);
+assign p[27] = `DIROUT(27);
+assign p[26] = `DIROUT(26);
+assign p[25] = `DIROUT(25);
+assign p[24] = `DIROUT(24);
+    
+assign p[23] = `DIROUT(23);
+assign p[22] = `DIROUT(22);
+assign p[21] = `DIROUT(21);
+assign p[20] = `DIROUT(20);
+assign p[19] = `DIROUT(19);
+assign p[18] = `DIROUT(18);
+assign p[17] = `DIROUT(17);
+assign p[16] = `DIROUT(16);
+    
+assign p[15] = `DIROUT(15);
+assign p[14] = `DIROUT(14);
+assign p[13] = `DIROUT(13);
+assign p[12] = `DIROUT(12);
+assign p[11] = `DIROUT(11);
+assign p[10] = `DIROUT(10);
+assign p[9] = `DIROUT(9);
+assign p[8] = `DIROUT(8);
+
+assign p[7] = `DIROUT(7);
+assign p[6] = `DIROUT(6);
+assign p[5] = `DIROUT(5);
+assign p[4] = `DIROUT(4);
+assign p[3] = `DIROUT(3);
+assign p[2] = `DIROUT(2);
+assign p[1] = `DIROUT(1);
+assign p[0] = `DIROUT(0);
+
+//
+// Clock generator for Altera FPGA's
+//
+
+wire clock_160;
+
+altera altera_(
+    .clock_50 (clock_50),
+    .clock_160 (clock_160)
+);
+
+//
+// Virtual Propeller
+//
+
+p1v p1v_(
+    .clock_160 (clock_160),
+    .inp_resn (resn),
+    .ledg (cogled[8:1]),
+    .pin_out (pin_out),
+    .pin_in (pin_in),
+    .pin_dir (pin_dir)
+);
+
+endmodule

--- a/HDL/fpga123_description.txt
+++ b/HDL/fpga123_description.txt
@@ -1,0 +1,2 @@
+Created on:Tuesday, July 28, 2015
+Based on:BeMicroCV-A9

--- a/P8X32A_FPGA123/readme.txt
+++ b/P8X32A_FPGA123/readme.txt
@@ -1,0 +1,29 @@
+To compile the P8X32A hardware description and load it into the Parallax 1-2-3-FPGA (A7):
+
+1) Open Quartus II (You will need version 15 or higher or you won't be able to use the free "web" version with this board).
+
+2) File | Open Project...
+
+3) Select 'P1V_Altera.qpf' file from this directory
+
+3a) Click Project | Revisions, and make sure the fpga123 revision is the current revision. If not, click on it, then click Set Current. Click OK to close the dialog.
+
+4) The 1-2-3 FPGA board requires a .rbf file be created by Quartus II. Check to make sure the project is set to create the .rbf file: from the main menu, select Assignments|Device, click on "Device and Pin Options...", click on "Programming Files", make sure "Raw Binary File (.rbf) is checked, click "Ok", click "Ok" and you should be ready to compile the verilog. 
+
+5) Press the 'play' button to start compilation (takes several minutes)
+
+** Unlike other FPGA boards typically used for P1V development, the 1-2-3 FPGA board has a Propeller on it that comes with a loader program pre-installed. It DOES NOT use the Quartus loader to load the FPGA image. You should already have the px.exe program from Parallax set up and tested. Installing px.exe and testing this is beyond this document as your final solution will vary depending on your development system choice. **
+
+6) connect the 1-2-3 FPGA board to your computer with a USB cable and connect a power supply.
+
+7) Set the PGM/RUN switch on the board to PGM, power up the board.
+
+8) run "px.exe <your_output>.rbf /P /n" - replace n with your com port number
+
+9) px.exe will open a status window and send the FPGA image to the board - during loading, your FPGA will continue to run whatever it was last loaded with. The USB lights will flash and the Conf Status light will flash as the new image is downloaded. When complete, the FPGA will reset and your new image will start running on the FPGA
+
+10) Change the PGM/RUN switch to RUN and your P1V should be connected to the USB port, ready to accept your Spin/PASM programs. As released, user LEDs GRN0-GRN7 are used to indicate COG0 through COG7 being active. GRN8-GRN15 are used to indicate COG0 through COG7 being inactive. The 3.3V I/O header onteh 1-2-3 FPGA board should map to Propeller pins 0-29 just like a real Propeller. Pins 30 and 31 are "hard wired" in the FPGA configuration to use the USB port for serial I/O.  
+
+11) You can now use your favorite Propeller programming tool to the P8X32A being emulated in the 1-2-3 FPGA board.
+
+Have fun!


### PR DESCRIPTION
Added fpga123.v, fpga123.qsf, readme.txt and updated P1V_Altera.qpf to support a new project revision to provide build support for the P1V image onto a Parallax 1-2-3- FPGA board.
