### PR TITLE
Fix Nexys4 breaks from reset module changes.

### DIFF
--- a/HDL/Nexys4.sv
+++ b/HDL/Nexys4.sv
@@ -126,7 +126,7 @@ wire                inp_res;
 
 reset reset_ (
     .clock_160      (clock_160),
-    .async_res      (~rts & ~reset),
+    .async_res      (~rts | ~reset),
     .res            (inp_res)
 );
           

--- a/HDL/Nexys4.xdc
+++ b/HDL/Nexys4.xdc
@@ -723,6 +723,7 @@ set_property IOSTANDARD LVCMOS33 [get_ports rts]
 #set_property PACKAGE_PIN U13 [get_ports {MemAdr[22]}]
 #set_property IOSTANDARD LVCMOS33 [get_ports {MemAdr[22]}]
 
+create_generated_clock -name clk_cog -source [get_pins genclock/CLKOUT0] -divide_by 2 [get_pins {p1v_/clkgen/divide_reg[12]/Q}] 
 set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 
 

--- a/HDL/P1V_Nexys4.xpr
+++ b/HDL/P1V_Nexys4.xpr
@@ -3,7 +3,7 @@
 <!--                                                         -->
 <!-- Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.   -->
 
-<Project Version="7" Minor="20" Path="D:/GitHub/P1V/HDL/P1V_Nexys4.xpr">
+<Project Version="7" Minor="20" Path="C:/Users/andrewsi/Documents/GitHub/P1V/HDL/P1V_Nexys4.xpr">
   <DefaultLaunch Dir="$PRUNDIR"/>
   <Configuration>
     <Option Name="Id" Val="f8760ea7963a40758a3b8134323837df"/>
@@ -128,7 +128,9 @@
   <Runs Version="1" Minor="10">
     <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7a100tcsg324-1" ConstrsSet="constrs_1" Description="Vivado Synthesis Defaults" State="current" Dir="$PRUNDIR/synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2016"/>
+        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2017">
+          <Desc>Vivado Synthesis Defaults</Desc>
+        </StratHandle>
         <Step Id="synth_design"/>
       </Strategy>
       <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
@@ -137,7 +139,9 @@
     </Run>
     <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a100tcsg324-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2016"/>
+        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2017">
+          <Desc>Default settings for Implementation.</Desc>
+        </StratHandle>
         <Step Id="init_design"/>
         <Step Id="opt_design"/>
         <Step Id="power_opt_design"/>

--- a/HDL/reset.sv
+++ b/HDL/reset.sv
@@ -25,20 +25,23 @@ module              reset
 input               clock_160,
 input               async_res,
 
-output              res
+output reg          res
 );
 
 parameter DELAY_CYCLES = 32'd8_000_000; // 50ms
 
 reg [31:0]          reset_cnt;
+wire                out_res;
 
-assign res = |reset_cnt;
+assign out_res = |reset_cnt;
 
+always @(posedge clock_160)
+    res <= out_res;
+    
 always @(posedge clock_160)
     if (async_res) begin
         reset_cnt <= DELAY_CYCLES;
-    end else if (res) begin
+    end else if (out_res) begin
         reset_cnt--;
     end
-
 endmodule


### PR DESCRIPTION
1. Register reset counter output to aid timing closure.
2. Restore missing constraints.