### PR TITLE
Replace excessive single-bit assignments with for-loop generate blocks.

### DIFF
--- a/HDL/Nexys4.sv
+++ b/HDL/Nexys4.sv
@@ -92,8 +92,6 @@ assign pin_in[31:0] = pin[31:0];
 wire[31:0] pin_out;
 wire[31:0] pin_dir;
 
-`define DIROUT(x) (pin_dir[x] ? pin_out[x] : 1'bZ)
-
 genvar i;
 generate
     for (i = 0; i < 32; i++)

--- a/HDL/Nexys4.sv
+++ b/HDL/Nexys4.sv
@@ -53,11 +53,11 @@ xilinx_clock #(
 
 wire[7:0] cogled;
 
-genvar l;
+genvar j;
 generate
-    for (l = 0; l < 8; l++)
+    for (j = 0; j < 8; j++)
     begin
-        assign ledg[l] = cogled[l];
+        assign ledg[j] = cogled[j];
     end
 endgenerate
     

--- a/HDL/Nexys4.sv
+++ b/HDL/Nexys4.sv
@@ -51,18 +51,16 @@ xilinx_clock #(
 // LEDs
 //
 
+wire[7:0] cogled;
 
-wire[8:1] cogled;
-assign ledg[0] = cogled[1];
-assign ledg[1] = cogled[2];
-assign ledg[2] = cogled[3];
-assign ledg[3] = cogled[4];
-assign ledg[4] = cogled[5];
-assign ledg[5] = cogled[6];
-assign ledg[6] = cogled[7];
-assign ledg[7] = cogled[8];
-
-
+genvar l;
+generate
+    for (l = 0; l < 8; l++)
+    begin
+        assign ledg[l] = cogled[l];
+    end
+endgenerate
+    
 //
 // Reset
 //
@@ -96,42 +94,13 @@ wire[31:0] pin_dir;
 
 `define DIROUT(x) (pin_dir[x] ? pin_out[x] : 1'bZ)
 
-assign pin[31] = `DIROUT(31);
-assign pin[30] = `DIROUT(30);
-assign pin[29] = `DIROUT(29);
-assign pin[28] = `DIROUT(28);
-assign pin[27] = `DIROUT(27);
-assign pin[26] = `DIROUT(26);
-assign pin[25] = `DIROUT(25);
-assign pin[24] = `DIROUT(24);
-
-assign pin[23] = `DIROUT(23);
-assign pin[22] = `DIROUT(22);
-assign pin[21] = `DIROUT(21);
-assign pin[20] = `DIROUT(20);
-assign pin[19] = `DIROUT(19);
-assign pin[18] = `DIROUT(18);
-assign pin[17] = `DIROUT(17);
-assign pin[16] = `DIROUT(16);
-
-assign pin[15] = `DIROUT(15);
-assign pin[14] = `DIROUT(14);
-assign pin[13] = `DIROUT(13);
-assign pin[12] = `DIROUT(12);
-assign pin[11] = `DIROUT(11);
-assign pin[10] = `DIROUT(10);
-assign pin[9]  = `DIROUT(9);
-assign pin[8]  = `DIROUT(8);
-
-assign pin[7]  = `DIROUT(7);
-assign pin[6]  = `DIROUT(6);
-assign pin[5]  = `DIROUT(5);
-assign pin[4]  = `DIROUT(4);
-assign pin[3]  = `DIROUT(3);
-assign pin[2]  = `DIROUT(2);
-assign pin[1]  = `DIROUT(1);
-assign pin[0]  = `DIROUT(0);
-
+genvar i;
+generate
+    for (i = 0; i < 32; i++)
+    begin
+        assign pin[i] = pin_dir[i] ? pin_out[i] : 1'bz;
+    end
+endgenerate
 
 //
 // Virtual Propeller
@@ -143,7 +112,7 @@ p1v #(
 ) p1v_ (
     .clock_160      (clock_160),
     .inp_resn       (~inp_res),
-    .ledg           (cogled[8:1]),
+    .ledg           (cogled),
     .pin_out        (pin_out),
     .pin_in         (pin_in),
     .pin_dir        (pin_dir)

--- a/HDL/P1V_Nexys4.xpr
+++ b/HDL/P1V_Nexys4.xpr
@@ -3,7 +3,7 @@
 <!--                                                         -->
 <!-- Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.   -->
 
-<Project Version="7" Minor="20" Path="C:/Users/andrewsi/Documents/GitHub/P1V/HDL/P1V_Nexys4.xpr">
+<Project Version="7" Minor="20" Path="D:/GitHub/P1V/HDL/P1V_Nexys4.xpr">
   <DefaultLaunch Dir="$PRUNDIR"/>
   <Configuration>
     <Option Name="Id" Val="f8760ea7963a40758a3b8134323837df"/>

--- a/HDL/P1V_Nexys4.xpr
+++ b/HDL/P1V_Nexys4.xpr
@@ -3,7 +3,7 @@
 <!--                                                         -->
 <!-- Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.   -->
 
-<Project Version="7" Minor="20" Path="D:/GitHub/P1V/HDL/P1V_Nexys4.xpr">
+<Project Version="7" Minor="20" Path="C:/Users/andrewsi/Documents/GitHub/P1V/HDL/P1V_Nexys4.xpr">
   <DefaultLaunch Dir="$PRUNDIR"/>
   <Configuration>
     <Option Name="Id" Val="f8760ea7963a40758a3b8134323837df"/>


### PR DESCRIPTION
This is just cleaner syntax for large 8 or 32 bit ports.  Should work generically with any FPGA, any brand.