### PR TITLE
Fixes a long standing bug in the clock divider (tim.v).  

### DIFF
--- a/HDL/tim.v
+++ b/HDL/tim.v
@@ -53,7 +53,7 @@ begin
          clksel == 5'b11110 && !res,                                                    // PLL8X
          clksel == 5'b11101 && !res,                                                    // PLL4X
         (clksel == 5'b11100 || clksel[2:0] == 3'b000) && !res,                          // PLL2X or RCFAST
-        (clksel == 5'b11011 || (clksel[4] == 1'b1 && clksel[2:0] == 3'b010)) && !res,   // PLL1X or XINPUT
+        (clksel == 5'b11011 || clksel == 5'b01010) && !res,                             // PLL1X or XINPUT
          1'b0,
          1'b0,
          1'b0,


### PR DESCRIPTION
The constant used to identify cogs running in any of the non-PLL XINPUT or XTAL modes was incorrect and would likely result in no clock being generated at all, since none of the matching expressions would have succeeded.  However, as use of these modes is relatively rare (for performance reasons), it's likely very few ever noticed in the simulator.